### PR TITLE
added NumpyDataset tutorial link to website

### DIFF
--- a/website/docs/notebooks/index.html
+++ b/website/docs/notebooks/index.html
@@ -115,6 +115,7 @@ them in Jupyter:</p>
 <li class="toctree-l1"><a class="reference internal" href="mnist.html">MNIST with DeepChem and TensorGraph</a></li>
 <li class="toctree-l1"><a class="reference internal" href="Conditional_GAN.html">Conditional Generative Adversarial Network</a></li>
 <li class="toctree-l1"><a class="reference internal" href="Splitters_Tutorial.html">Using DeepChem Splitters</a></li>
+<li class="toctree-l1"><a class="reference internal" href="Deepchem_NumpyDataset_tutorial.html">Using DeepChem NumpyDataset</a></li>
 <li class="toctree-l1"><a class="reference internal" href="MNIST_GAN.html">MNIST GAN</a></li>
 <li class="toctree-l1"><a class="reference internal" href="pong.html">Pong in DeepChem with A3C</a></li>
 <li class="toctree-l1"><a class="reference internal" href="seqtoseq_fingerprint.html">SeqToSeq Fingerprint</a></li>


### PR DESCRIPTION
Added the link of [NumpyDataset Tutorial](https://github.com/deepchem/deepchem/pull/1116) in the website's notebook examples webpage.