### PR TITLE
Add all channels, python 3.6 not available

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -166,27 +166,27 @@
 
     }(jQuery, {
 
-        'conda,linux,no,python2.7': 'conda install -c deepchem deepchem=2.1.0 python=2.7',
+        'conda,linux,no,python2.7': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.1.0 python=2.7',
 
-        'conda,linux,yes,python2.7': 'conda install -c deepchem deepchem-gpu=2.1.0 python=2.7',
+        'conda,linux,yes,python2.7': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem-gpu=2.1.0 python=2.7',
 
-        'conda,linux,no,python3.5': 'conda install -c deepchem deepchem=2.1.0 python=3.5',
+        'conda,linux,no,python3.5': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.1.0 python=3.5',
 
-        'conda,linux,yes,python3.5': 'conda install -c deepchem deepchem-gpu=2.1.0 python=3.5',
+        'conda,linux,yes,python3.5': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem-gpu=2.1.0 python=3.5',
 
-        'conda,linux,no,python3.6': 'conda install -c deepchem deepchem=2.1.0 python=3.6',
+        'conda,linux,no,python3.6': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.1.0 python=3.6',
 
-        'conda,linux,yes,python3.6': 'conda install -c deepchem deepchem-gpu=2.1.0 python=3.6',
+        'conda,linux,yes,python3.6': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem-gpu=2.1.0 python=3.6',
 
-        'conda,osx,no,python2.7': 'conda install -c deepchem deepchem=2.1.0 python=2.7',
+        'conda,osx,no,python2.7': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.1.0 python=2.7',
 
         'conda,osx,yes,python2.7': 'We do not support GPU enabled OSX deploys',
 
-        'conda,osx,no,python3.5': 'conda install -c deepchem deepchem=2.1.0 python=3.5',
+        'conda,osx,no,python3.5': 'conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.1.0 python=3.5',
 
         'conda,osx,yes,python3.5': 'We do not support GPU enabled OSX deploys',
 
-        'conda,osx,no,python3.6': 'conda install -c deepchem deepchem=2.1.0 python=3.6',
+        'conda,osx,no,python3.6': 'Python 3.6 is not yet available for OSX deploys of deepchem',
 
         'conda,osx,yes,python3.6': 'We do not support GPU enabled OSX deploys',
 


### PR DESCRIPTION
1. Add all the channels necessary to install deepchem. Taken from https://github.com/deepchem/deepchem.io/blob/master/website/about.html
2. A python 3.6 version of deepchem is not currently available on OSX. I haven't looked into whether this is intentional or a build error in the deepchem package. https://anaconda.org/deepchem/deepchem/files