### PR TITLE
Added installation option for python=3.7

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -63,7 +63,8 @@
                     <div class="option-set">
                         <div class="btn">2.7</div>
                         <div class="btn">3.5</div>
-                        <div class="btn selected">3.6</div>
+                        <div class="btn">3.6</div>
+                        <div class="btn selected">3.7</div>
                     </div>
                 </div>
                 <div class="option-row os" data-key="gpu">
@@ -134,7 +135,7 @@
             gpu: 'NO',
             os: 'linux',
             pm: 'conda',
-            python: '3.5'
+            python: '3.7'
         };
 
         function buildMatcher() {
@@ -178,6 +179,10 @@
 
         'conda,linux,yes,python3.6': 'conda install -c deepchem deepchem-gpu=2.2.0 python=3.6',
 
+        'conda,linux,no,python3.7': 'conda install -c deepchem deepchem=2.2.0 python=3.7',
+
+        'conda,linux,yes,python3.7': 'conda install -c deepchem deepchem-gpu=2.2.0 python=3.7',
+
         'conda,osx,no,python2.7': 'conda install -c deepchem deepchem=2.2.0 python=2.7',
 
         'conda,osx,yes,python2.7': 'We do not support GPU enabled OSX deploys',
@@ -189,6 +194,10 @@
         'conda,osx,no,python3.6': 'conda install -c deepchem deepchem=2.2.0 python=3.6',
 
         'conda,osx,yes,python3.6': 'We do not support GPU enabled OSX deploys',
+
+        'conda,osx,no,python3.7': 'conda install -c deepchem deepchem=2.2.0 python=3.7',
+
+        'conda,osx,yes,python3.7': 'We do not support GPU enabled OSX deploys',
 
         'docker,osx,no,python2.7': 'docker pull deepchemio/deepchem<br>docker run -i -t deepchemio/deepchem:2.2.0-cpu',
 
@@ -202,6 +211,10 @@
 
         'docker,osx,yes,python3.6': 'We do not support GPU enabled OSX deploys',
 
+        'docker,osx,no,python3.7': 'docker pull deepchemio/deepchem<br>docker run -i -t deepchemio/deepchem:2.2.0-cpu',
+
+        'docker,osx,yes,python3.7': 'We do not support GPU enabled OSX deploys',
+
         'docker,linux,no,python2.7': 'docker pull deepchemio/deepchem<br>docker run -i -t deepchemio/deepchem:2.2.0-cpu',
 
         'docker,linux,yes,python2.7': 'docker pull deepchemio/deepchem<br>nvidia-docker run -i -t deepchemio/deepchem',
@@ -212,7 +225,11 @@
 
         'docker,linux,no,python3.6': 'docker pull deepchemio/deepchem<br>docker run -i -t deepchemio/deepchem:2.2.0-cpu',
 
-        'docker,linux,yes,python3.6': 'docker pull deepchemio/deepchem<br>nvidia-docker run -i -t deepchemio/deepchem'
+        'docker,linux,yes,python3.6': 'docker pull deepchemio/deepchem<br>nvidia-docker run -i -t deepchemio/deepchem',
+
+        'docker,linux,no,python3.7': 'docker pull deepchemio/deepchem<br>docker run -i -t deepchemio/deepchem:2.2.0-cpu',
+
+        'docker,linux,yes,python3.7': 'docker pull deepchemio/deepchem<br>nvidia-docker run -i -t deepchemio/deepchem'
     }));
 
 </script>


### PR DESCRIPTION
Pull request to solve the issue https://github.com/deepchem/deepchem/issues/1693. Also, should the python 2.7 be removed? Python 2.7 is not supported anymore and I am not sure if it is even compatible with recent versions of deepchem?