### PR TITLE
Hotfix: fix s3cmd old version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
 - '3.5'
 dist: trusty
 install:
-- pip install s3cmd
-- pip install delegator.py
+- pip install s3cmd==2.0.2
+- pip install delegator.py==0.1.1
 script:
 - python devtools/create_key_file.py
 - python devtools/push-docs-to-s3.py

--- a/devtools/push-docs-to-s3.py
+++ b/devtools/push-docs-to-s3.py
@@ -14,20 +14,20 @@ if not any(d.project_name == 's3cmd'
            for d in get_installed_distributions()):
   raise ImportError('The s3cmd package is required. try $ pip install s3cmd')
 
-template = "s3cmd -M -H --config {config} sync website/ s3://{bucket}/"
+template = ('s3cmd -M -H --config {config} ' 'sync website/ s3://{bucket}/')
 cmd = template.format(config='keys.crt', bucket=BUCKET_NAME)
 c = delegator.run(cmd)
 c.block()
 print(c.out)
 
-template = "s3cmd --recursive modify --add-header='content-type':'text/css' --include '.css' --config {config} s3://{bucket}/"
+template = "s3cmd --recursive modify --add-header='content-type':'text/css' --exclude '' --include '.css' --config {config} s3://{bucket}/"
 cmd = template.format(config='keys.crt', bucket=BUCKET_NAME)
 print(cmd)
 c = delegator.run(cmd)
 c.block()
 print(c.out)
 
-template = "s3cmd --recursive modify --add-header='content-type':'application/javascript' --include '.js' --config {config} s3://{bucket}/"
+template = "s3cmd --recursive modify --add-header='content-type':'application/javascript' --exclude '' --include '.js' --config {config} s3://{bucket}/"
 cmd = template.format(config='keys.crt', bucket=BUCKET_NAME)
 c = delegator.run(cmd)
 print(c.out)


### PR DESCRIPTION
I seem the deploy is not successful after this PR https://github.com/deepchem/deepchem.io/pull/23 (March)

When I confirmed the s3cmd version, the new s3cmd is published in two years from the last release in April.
https://pypi.org/project/s3cmd/2.0.2/#history

This version bump up may lead to fail to deploy.  So, I fixed the old version.